### PR TITLE
Create virtio_win_facts dir before setting up facts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,12 @@
   register: register_virtio_changelog
   delegate_to: localhost
 
+- name: create facts virtio dir
+  win_file:
+    path: '{{ virtio_win_facts }}'
+    state: directory
+  when: ansible_os_family == 'Windows'
+
 - name: setup facts virtio
   setup:
     fact_path: '{{ virtio_win_facts }}'


### PR DESCRIPTION
The task `setup facts virtio` failed when trying to access a non-existent `virtio win facts`, I added a task to create this directory, preventing this error from occurring.